### PR TITLE
Optimizations: arrow -> duckdb & netcdf -> geotif + stars_proxy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,10 @@ Imports:
     raster,
     future,
     future.apply,
-    furrr
+    furrr,
+    DBI,
+    duckdb,
+    dbplyr
 License: Apache License (== 2.0) | file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/fn-heatwave.R
+++ b/R/fn-heatwave.R
@@ -325,9 +325,9 @@ generate_pixel_climatologies <- function(stars_cube, start_date, end_date) {
 
   # Long data frame of tmax for every pixel for every date
   all_temps <- as.data.frame(stars_cube) |>
+    dplyr::filter(!is.na(tmax)) |> # This assumes that each pixel either has a complete time series, or all temps are NA. I think this is reasonable
     dplyr::mutate(time = as.Date(time)) |>
     dplyr::rename(t = time, temp = tmax) |>
-    dplyr::filter(!is.na(temp)) |> # This assumes that each pixel either has a complete time series, or all temps are NA. I think this is reasonable
     dplyr::mutate(pixel_id = paste(x, y, sep = ";"))
 
   all_temps_split <- split(all_temps, all_temps$pixel_id)

--- a/R/fn-heatwave.R
+++ b/R/fn-heatwave.R
@@ -347,7 +347,7 @@ generate_pixel_climatologies <- function(stars_cube, start_date, end_date) {
 #' @return tibble with x, y, pixel_id (concatenation of x & y),
 #' and variables supplied in `group_vars`
 pixel_aoi_lookup <- function(stars_cube, area_of_interest, group_vars) {
-  rast <- dplyr::slice(stars_cube, "time", 1)
+  rast <- dplyr::slice(stars_cube[area_of_interest], "time", 1)
   as.data.frame(rast) |>
     dplyr::select(-tmax) |>
     dplyr::mutate(pixel_id = paste(x, y, sep = ";")) |>

--- a/R/fn-heatwave.R
+++ b/R/fn-heatwave.R
@@ -265,6 +265,8 @@ make_stars_cube <- function(files, variable) {
 
   stars_proxy_obj <- stars::read_stars(files,
                           proxy = TRUE,
+                          # cannot supply a list of dimensions to 'along' for proxy objects,
+                          # so must do it after the fact
                           # along = list(time = as.Date(names(model_list)))
                           along = "time"
   )

--- a/_targets.R
+++ b/_targets.R
@@ -32,8 +32,12 @@ dir.create("data", showWarnings = FALSE)
 ## Source functions
 r_files <- list.files("R", pattern = "*.R", full.names = TRUE)
 dump <- lapply(r_files, source, echo = FALSE, verbose = FALSE)
+
 if (.Platform$OS.type == "windows") options("arrow.use_threads" = FALSE)
-future::plan(future::multisession(workers = 6))
+
+# future options
+future::plan(future::multisession(workers = 4))
+options(future.globals.maxSize = 1000 * 1024 ^ 2)
 
 ## Create output directories:
 hw_output_dir <- "out/heatwave_summaries"

--- a/_targets.R
+++ b/_targets.R
@@ -105,13 +105,11 @@ climate_targets <- list(
   tar_target(daily_tmax_models, model_temps_xyz(temp_data = dplyr::filter(analysis_temps, measure == "daily_max"),
                                            stations = target_stations,
                                            months = 1:12, future.seed = 13L)),
-  tar_target(daily_temps_stars_cube,
-             interpolate_daily_temps(daily_tmax_models,
-                                     dem[area_of_interest], "tmax")),
-  tar_target(out_ncdf, write_ncdf(daily_temps_stars_cube,
-                                  path = paste0("out/data/daily_temps_",
-                                                start_date, "-", end_date, ".nc")),
-                                  format = "file")
+  tar_target(model_output_tifs, interpolate_daily_temps(daily_tmax_models,
+                                                        dem[area_of_interest], "tmax",
+                                                        path = paste0("out/data/daily_temps/")),
+             format = "file"),
+  tar_target(daily_temps_stars_cube, make_stars_cube(model_output_tifs, "tmax"))
 )
 
 heatwave_targets <- list(

--- a/_targets.R
+++ b/_targets.R
@@ -110,14 +110,14 @@ climate_targets <- list(
                                            stations = target_stations,
                                            months = 1:12, future.seed = 13L)),
   tar_target(model_output_tifs, interpolate_daily_temps(daily_tmax_models,
-                                                        dem[area_of_interest], "tmax",
+                                                        dem, "tmax",
                                                         path = paste0("out/data/daily_temps/")),
              format = "file"),
   tar_target(daily_temps_stars_cube, make_stars_cube(model_output_tifs, "tmax"))
 )
 
 heatwave_targets <- list(
-  tar_target(pixel_clims, generate_pixel_climatologies(daily_temps_stars_cube,
+  tar_target(pixel_clims, generate_pixel_climatologies(daily_temps_stars_cube[area_of_interest],
                                                        start_date = start_date,
                                                        end_date = end_date)),
   tar_target(pixel_aoi_lup, pixel_aoi_lookup(daily_temps_stars_cube, area_of_interest,


### PR DESCRIPTION
This PR addresses two performance/scalability issues.

1. Use duckdb vs arrow to store and retrieve raw ECCC temperature data. This increases the storage size but vastly speeds up both the creation of the data from txt files and querying and retrieval of the data (FWIW this is a strange case for arrow as it should be very fast - possibly a bug).

2. For the daily gridded temperature surfaces, switch to writing geotifs for each day as they are created rather than creating all at once, holding in memory, and writing as a single netcdf file. These geotiffs are now 'read' all together as a `stars_proxy` object which just contains pointers to the files and only subsets of the data are actually loaded into memory as needed. This optimization should facilitate expansion both in scope (i.e., greater than a handful of LHAs) and resolution (if necessary).

Fixes #13 (doesn't really as it just avoids arrow)